### PR TITLE
Fix -Wformat-security error

### DIFF
--- a/src/GameSpy/GP/gpiKeys.c
+++ b/src/GameSpy/GP/gpiKeys.c
@@ -172,7 +172,7 @@ GPResult gpiSaveKeysToBuffer(GPConnection *connection, char **buffer)
 		gsDebugFormat(GSIDebugCat_GP, GSIDebugType_Memory, GSIDebugLevel_HotError, "gpiSaveKeysToBuffer: buffer Out of memory.");
 		Error(connection, GP_MEMORY_ERROR, "Out of memory.");
 	}
-	bytesWritten = sprintf(*buffer, keysHeader);
+	bytesWritten = sprintf(*buffer, "%s", keysHeader);
 	tempPoint = *buffer + bytesWritten;
 	for (i = 0; i < aLength; i++)
 	{


### PR DESCRIPTION
Building OpenXRay with [Nixpkgs' `format` hardening compiler flags](https://nixos.org/manual/nixpkgs/stable/#sec-hardening-in-nixpkgs) (`-Wformat -Wformat-security -Werror=format-security`) errors out on this line.

```
[  6%] Building C object Externals/GameSpy/CMakeFiles/GameSpy.dir/src/GameSpy/GP/gpiKeys.c.o
/build/source/Externals/GameSpy/src/GameSpy/GP/gpiKeys.c: In function 'gpiSaveKeysToBuffer':
/build/source/Externals/GameSpy/src/GameSpy/GP/gpiKeys.c:175:34: error: format not a string literal and no format arguments [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security8;;]
  175 |  bytesWritten = sprintf(*buffer, keysHeader);
      |                                  ^~~~~~~~~~
cc1: some warnings being treated as errors
make[2]: *** [Externals/GameSpy/CMakeFiles/GameSpy.dir/build.make:589: Externals/GameSpy/CMakeFiles/GameSpy.dir/src/GameSpy/GP/gpiKeys.c.o] Error 1
```

Untested but it seems like a pretty straight-forward fix. This lets us enable full hardening for OpenXRay when the next release gets tagged. (https://github.com/NixOS/nixpkgs/blob/ce93c98ce2243a8228419fcfbe97fd87f3c5f99e/pkgs/games/openxray/default.nix#L41)